### PR TITLE
chore: Add unit tests

### DIFF
--- a/birdie_snapshots/should_error_because_of_name_conflict.accepted
+++ b/birdie_snapshots/should_error_because_of_name_conflict.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should error because of name conflict
+---
+InterfaceError: There is both a type and value with that name. Please specify -t or -v to print the one you want

--- a/birdie_snapshots/should_error_because_value_doesn't_exist.accepted
+++ b/birdie_snapshots/should_error_because_value_doesn't_exist.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should error because value doesn't exist
+---
+InterfaceError: No item has been found with the name NonExistent

--- a/birdie_snapshots/should_parse_all_arguments.accepted
+++ b/birdie_snapshots/should_parse_all_arguments.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should parse all arguments
+---
+Document("lustre.Error", Type, Some("~/.cache"), True)

--- a/birdie_snapshots/should_parse_help_argument.accepted
+++ b/birdie_snapshots/should_parse_help_argument.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should parse help argument
+---
+Help

--- a/birdie_snapshots/should_print_custom_type.accepted
+++ b/birdie_snapshots/should_print_custom_type.accepted
@@ -1,0 +1,16 @@
+---
+version: 1.2.0
+title: Should print custom type
+---
+Documentation for type `MyResult` in `module`:
+
+pub type MyResult(a, b) {
+  Ok(value: a, extra_info: b)
+  Error(message: String)
+}
+
+Custom implementation of Result type
+
+
+/!\ This item has been deprecated :
+Just use Result

--- a/birdie_snapshots/should_print_deprecated_module_constant.accepted
+++ b/birdie_snapshots/should_print_deprecated_module_constant.accepted
@@ -1,0 +1,13 @@
+---
+version: 1.2.0
+title: Should print deprecated module constant
+---
+Documentation for value `constant` in `module`:
+
+pub const constant: Nil
+
+This holds a constant value
+
+
+/!\ This item has been deprecated :
+You don't need a constant for Nil, silly

--- a/birdie_snapshots/should_print_module_constant.accepted
+++ b/birdie_snapshots/should_print_module_constant.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.2.0
+title: Should print module constant
+---
+Documentation for value `constant` in `module`:
+
+pub const constant: Option(Int)
+
+This holds a constant value

--- a/birdie_snapshots/should_print_module_documentation.accepted
+++ b/birdie_snapshots/should_print_module_documentation.accepted
@@ -1,0 +1,12 @@
+---
+version: 1.2.0
+title: Should print module documentation
+file: ./test/gleamoire_test.gleam
+test_name: module_documentation_test
+---
+Help on module `mod`:
+
+Documentation for module `mod`
+# The mod module
+## This is a subheading
+This module does things

--- a/birdie_snapshots/should_print_module_function.accepted
+++ b/birdie_snapshots/should_print_module_function.accepted
@@ -1,0 +1,12 @@
+---
+version: 1.2.0
+title: Should print module function
+---
+Documentation for value `func` in `module`:
+
+pub fn func(
+  Int, 
+  float: Float
+) -> Bool
+
+Does stuff

--- a/birdie_snapshots/should_print_module_items.accepted
+++ b/birdie_snapshots/should_print_module_items.accepted
@@ -1,0 +1,22 @@
+---
+version: 1.2.0
+title: Should print module items
+file: ./test/gleamoire_test.gleam
+test_name: module_items_test
+---
+Help on module `mod2`:
+
+Available items
+> Types
+  - MyAlias
+  - MyType
+
+> Values
+  - MyConstructor
+  - my_constant
+  - my_function
+
+Documentation for module `mod2`
+# The other module, mod2
+## Another subheading
+This module does other things

--- a/birdie_snapshots/should_print_submodules_of_a_module.accepted
+++ b/birdie_snapshots/should_print_submodules_of_a_module.accepted
@@ -1,0 +1,17 @@
+---
+version: 1.2.0
+title: Should print submodules of a module
+file: ./test/gleamoire_test.gleam
+test_name: module_submodule_test
+---
+Help on module `mod`:
+
+Available submodules
+  - mod/sub
+  - mod/sub/other
+  - mod/sub2
+
+Documentation for module `mod`
+# The mod module
+## This is a subheading
+This module does things

--- a/birdie_snapshots/should_print_type_alias.accepted
+++ b/birdie_snapshots/should_print_type_alias.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.2.0
+title: Should print type alias
+---
+Documentation for type `Alias` in `module`:
+
+type Alias(a) = Result(a, Nil)
+
+This is an alias for Result(a, Nil)

--- a/birdie_snapshots/should_print_type_with_name.accepted
+++ b/birdie_snapshots/should_print_type_with_name.accepted
@@ -1,0 +1,9 @@
+---
+version: 1.2.0
+title: Should print type with name
+---
+Documentation for type `Wibble` in `module`:
+
+pub type Wibble {
+  Wibble
+}

--- a/birdie_snapshots/should_report_error_for_duplicate_cache_flags.accepted
+++ b/birdie_snapshots/should_report_error_for_duplicate_cache_flags.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report error for duplicate cache flags
+---
+InputError: Custom cache location should only be specified once

--- a/birdie_snapshots/should_report_error_for_duplicate_flags.accepted
+++ b/birdie_snapshots/should_report_error_for_duplicate_flags.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report error for duplicate flags
+---
+InputError: Flags can only be specified once

--- a/birdie_snapshots/should_report_error_for_specifying_multiple_modules.accepted
+++ b/birdie_snapshots/should_report_error_for_specifying_multiple_modules.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report error for specifying multiple modules
+---
+InputError: Please only specify one module to document

--- a/birdie_snapshots/should_report_no_cache_path_error.accepted
+++ b/birdie_snapshots/should_report_no_cache_path_error.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report no cache path error
+---
+InputError: No cache path provided

--- a/birdie_snapshots/should_report_no_module_error.accepted
+++ b/birdie_snapshots/should_report_no_module_error.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report no module error
+---
+InputError: Please specify a module to document. See gleamoire --help for more information

--- a/birdie_snapshots/should_report_t_and_v_error.accepted
+++ b/birdie_snapshots/should_report_t_and_v_error.accepted
@@ -1,0 +1,5 @@
+---
+version: 1.2.0
+title: Should report -t and -v error
+---
+InputError: Only one of -t and -v may be specified

--- a/gleam.toml
+++ b/gleam.toml
@@ -27,3 +27,4 @@ gleam_http = ">= 3.6.0 and < 4.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+birdie = ">= 1.2.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,10 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
+  { name = "birdie", version = "1.2.0", build_tools = ["gleam"], requirements = ["argv", "edit_distance", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "7EE6286C5660650143A5AC69E1D900DA1B6EAF3C6EBB7E50AC3DBF06511279CC" },
+  { name = "edit_distance", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "edit_distance", source = "hex", outer_checksum = "A1E485C69A70210223E46E63985FA1008B8B2DDA9848B7897469171B29020C05" },
   { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
+  { name = "glance", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "8F3314D27773B7C3B9FB58D8C02C634290422CE531988C0394FA0DF8676B964D" },
   { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
   { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
@@ -16,16 +19,21 @@ packages = [
   { name = "glearray", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glearray", source = "hex", outer_checksum = "B99767A9BC63EF9CC8809F66C7276042E5EFEACAA5B25188B552D3691B91AC6D" },
   { name = "gleescript", version = "1.4.0", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "8CDDD29F91064E69950A91A40061785F10275ADB70A0520075591F61A724C455" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
   { name = "glitzer", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "glearray", "repeatedly"], otp_app = "glitzer", source = "hex", outer_checksum = "7EB486050AD5A89E14DD6F89798A69103EA4245767A599CB9AF25E357A48AB46" },
+  { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
+  { name = "rank", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "rank", source = "hex", outer_checksum = "5660E361F0E49CBB714CC57CC4C89C63415D8986F05B2DA0C719D5642FAD91C9" },
   { name = "repeatedly", version = "2.1.1", build_tools = ["gleam"], requirements = [], otp_app = "repeatedly", source = "hex", outer_checksum = "38808C3EC382B0CD981336D5879C24ECB37FCB9C1D1BD128F7A80B0F74404D79" },
   { name = "simplifile", version = "2.0.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "5FFEBD0CAB39BDD343C3E1CCA6438B2848847DC170BA2386DF9D7064F34DF000" },
   { name = "snag", version = "0.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "54D32E16E33655346AA3E66CBA7E191DE0A8793D2C05284E3EFB90AD2CE92BCC" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
   { name = "tom", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "9EECB60150E834A07238BD5C7DF1FF07F7D4C5862BB8A773923D1981C7875FB0" },
+  { name = "trie_again", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "trie_again", source = "hex", outer_checksum = "5B19176F52B1BD98831B57FDC97BD1F88C8A403D6D8C63471407E78598E27184" },
 ]
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
+birdie = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_http = { version = ">= 3.6.0 and < 4.0.0" }
 gleam_httpc = { version = ">= 2.2.0 and < 3.0.0" }
 gleam_json = { version = ">= 1.0.1 and < 2.0.0" }

--- a/src/gleamoire/render.gleam
+++ b/src/gleamoire/render.gleam
@@ -111,7 +111,9 @@ pub fn document_item(
 }
 
 fn render_item(item: SimpleItem, module_name: String) -> String {
-  "Documentation for item `"
+  "Documentation for "
+  <> item.kind
+  <> " `"
   <> item.name
   <> "` in `"
   <> module_name
@@ -142,6 +144,7 @@ type ValueInterface {
 type SimpleItem {
   SimpleItem(
     name: String,
+    kind: String,
     representation: String,
     documentation: Option(String),
     deprecation: Option(String),
@@ -216,8 +219,7 @@ fn simplify_type(name: String, type_: TypeInterface) -> SimpleItem {
       0 -> ""
       n ->
         "("
-        <> n
-        |> list.range(0, _)
+        <> list.range(0, n - 1)
         |> list.map(get_variable_symbol)
         |> string.join(", ")
         <> ")"
@@ -242,7 +244,7 @@ fn simplify_type(name: String, type_: TypeInterface) -> SimpleItem {
     Type(t) -> option.map(t.deprecation, fn(d: pi.Deprecation) { d.message })
     Alias(a) -> option.map(a.deprecation, fn(d: pi.Deprecation) { d.message })
   }
-  SimpleItem(name:, documentation:, deprecation:, representation:)
+  SimpleItem(name:, kind: "type", documentation:, deprecation:, representation:)
 }
 
 fn simplify_value(name: String, value: ValueInterface) -> SimpleItem {
@@ -266,7 +268,13 @@ fn simplify_value(name: String, value: ValueInterface) -> SimpleItem {
       option.map(c.deprecation, fn(d: pi.Deprecation) { d.message })
     Constructor(..) -> None
   }
-  SimpleItem(name:, documentation:, deprecation:, representation:)
+  SimpleItem(
+    name:,
+    kind: "value",
+    documentation:,
+    deprecation:,
+    representation:,
+  )
 }
 
 fn render_constructor(c: pi.TypeConstructor) -> String {

--- a/test/gleamoire_test.gleam
+++ b/test/gleamoire_test.gleam
@@ -1,5 +1,438 @@
+import birdie
+import gleam/dict
+import gleam/option.{None, Some}
+import gleam/package_interface as pi
+import gleam/string
+import gleamoire/args
+import gleamoire/error
+import gleamoire/render
 import gleeunit
+import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
+}
+
+fn empty_module() {
+  pi.Module(
+    documentation: [],
+    type_aliases: dict.new(),
+    types: dict.new(),
+    constants: dict.new(),
+    functions: dict.new(),
+  )
+}
+
+fn empty_package() {
+  pi.Package(
+    name: "pack",
+    version: "1.0.0",
+    gleam_version_constraint: None,
+    modules: dict.new(),
+  )
+}
+
+fn gleam_type(name: String) -> pi.Type {
+  pi.Named(name:, package: "gleam", module: "gleam", parameters: [])
+}
+
+const implementations = pi.Implementations(True, False, False)
+
+pub fn module_documentation_test() {
+  render.document_module(
+    "mod",
+    pi.Module(
+      ..empty_module(),
+      documentation: [
+        "# The mod module", "## This is a subheading", "This module does things",
+      ],
+    ),
+    empty_package(),
+  )
+  |> birdie.snap("Should print module documentation")
+}
+
+pub fn module_items_test() {
+  render.document_module(
+    "mod2",
+    pi.Module(
+      documentation: [
+        "# The other module, mod2", "## Another subheading",
+        "This module does other things",
+      ],
+      type_aliases: [
+        #(
+          "MyAlias",
+          pi.TypeAlias(
+            documentation: None,
+            deprecation: None,
+            parameters: 1,
+            alias: pi.Variable(1),
+          ),
+        ),
+      ]
+        |> dict.from_list(),
+      types: [
+        #(
+          "MyType",
+          pi.TypeDefinition(
+            documentation: None,
+            deprecation: None,
+            parameters: 0,
+            constructors: [
+              pi.TypeConstructor(
+                documentation: None,
+                name: "MyConstructor",
+                parameters: [],
+              ),
+            ],
+          ),
+        ),
+      ]
+        |> dict.from_list(),
+      constants: [
+        #(
+          "my_constant",
+          pi.Constant(
+            documentation: None,
+            deprecation: None,
+            implementations:,
+            type_: gleam_type("Int"),
+          ),
+        ),
+      ]
+        |> dict.from_list(),
+      functions: [
+        #(
+          "my_function",
+          pi.Function(
+            documentation: None,
+            deprecation: None,
+            implementations:,
+            parameters: [],
+            return: gleam_type("Nil"),
+          ),
+        ),
+      ]
+        |> dict.from_list(),
+    ),
+    empty_package(),
+  )
+  |> birdie.snap("Should print module items")
+}
+
+pub fn module_submodule_test() {
+  render.document_module(
+    "mod",
+    pi.Module(
+      ..empty_module(),
+      documentation: [
+        "# The mod module", "## This is a subheading", "This module does things",
+      ],
+    ),
+    pi.Package(
+      ..empty_package(),
+      modules: [
+          #("mod/sub", empty_module()),
+          #("mod/sub2", empty_module()),
+          #("mod/sub/other", empty_module()),
+        ]
+        |> dict.from_list,
+    ),
+  )
+  |> birdie.snap("Should print submodules of a module")
+}
+
+pub fn constant_item_test() {
+  render.document_item(
+    "constant",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      constants: [
+          #(
+            "constant",
+            pi.Constant(
+              documentation: Some("This holds a constant value"),
+              deprecation: None,
+              implementations:,
+              type_: pi.Named(
+                name: "Option",
+                package: "gleam_stdlib",
+                module: "gleam/option",
+                parameters: [gleam_type("Int")],
+              ),
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print module constant")
+}
+
+pub fn function_item_test() {
+  render.document_item(
+    "func",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      functions: [
+          #(
+            "func",
+            pi.Function(
+              documentation: Some("Does stuff"),
+              deprecation: None,
+              implementations:,
+              parameters: [
+                pi.Parameter(label: None, type_: gleam_type("Int")),
+                pi.Parameter(label: Some("float"), type_: gleam_type("Float")),
+              ],
+              return: gleam_type("Bool"),
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print module function")
+}
+
+pub fn deprecated_item_test() {
+  render.document_item(
+    "constant",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      constants: [
+          #(
+            "constant",
+            pi.Constant(
+              documentation: Some("This holds a constant value"),
+              deprecation: Some(pi.Deprecation(
+                "You don't need a constant for Nil, silly",
+              )),
+              implementations:,
+              type_: gleam_type("Nil"),
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print deprecated module constant")
+}
+
+pub fn type_alias_test() {
+  render.document_item(
+    "Alias",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      type_aliases: [
+          #(
+            "Alias",
+            pi.TypeAlias(
+              documentation: Some("This is an alias for Result(a, Nil)"),
+              deprecation: None,
+              parameters: 1,
+              alias: pi.Named("Result", "gleam", "gleam", [
+                pi.Variable(0),
+                gleam_type("Nil"),
+              ]),
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print type alias")
+}
+
+pub fn custom_type_test() {
+  render.document_item(
+    "MyResult",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      types: [
+          #(
+            "MyResult",
+            pi.TypeDefinition(
+              documentation: Some("Custom implementation of Result type"),
+              deprecation: Some(pi.Deprecation("Just use Result")),
+              parameters: 2,
+              constructors: [
+                pi.TypeConstructor(
+                  documentation: Some("The Ok value"),
+                  name: "Ok",
+                  parameters: [
+                    pi.Parameter(Some("value"), pi.Variable(0)),
+                    pi.Parameter(Some("extra_info"), pi.Variable(1)),
+                  ],
+                ),
+                pi.TypeConstructor(
+                  documentation: Some("The Error value"),
+                  name: "Error",
+                  parameters: [
+                    pi.Parameter(Some("message"), gleam_type("String")),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print custom type")
+}
+
+pub fn unknown_item_error_test() {
+  render.document_item(
+    "NonExistent",
+    "module",
+    empty_module(),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should error because value doesn't exist")
+}
+
+pub fn item_conflict_error_test() {
+  render.document_item(
+    "Wibble",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      types: [
+          #(
+            "Wibble",
+            pi.TypeDefinition(
+              documentation: None,
+              deprecation: None,
+              parameters: 0,
+              constructors: [
+                pi.TypeConstructor(
+                  documentation: None,
+                  name: "Wibble",
+                  parameters: [],
+                ),
+              ],
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Unspecified,
+  )
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should error because of name conflict")
+}
+
+pub fn item_conflict_resolution_test() {
+  render.document_item(
+    "Wibble",
+    "module",
+    pi.Module(
+      ..empty_module(),
+      types: [
+          #(
+            "Wibble",
+            pi.TypeDefinition(
+              documentation: None,
+              deprecation: None,
+              parameters: 0,
+              constructors: [
+                pi.TypeConstructor(
+                  documentation: None,
+                  name: "Wibble",
+                  parameters: [],
+                ),
+              ],
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Type,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should print type with name")
+}
+
+pub fn args_test() {
+  args.parse(["-t", "lustre.Error", "-C", "~/.cache", "-r"])
+  |> should.be_ok
+  |> string.inspect
+  |> birdie.snap("Should parse all arguments")
+}
+
+pub fn help_args_test() {
+  args.parse(["--help"])
+  |> should.be_ok
+  |> string.inspect
+  |> birdie.snap("Should parse help argument")
+}
+
+pub fn args_tv_error_test() {
+  args.parse(["gleamoire.main", "-t", "-v"])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report -t and -v error")
+}
+
+pub fn args_no_module_error_test() {
+  args.parse(["--type"])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report no module error")
+}
+
+pub fn args_no_cache_path_error_test() {
+  args.parse(["gleam/int.to_string", "--cache"])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report no cache path error")
+}
+
+pub fn args_two_modules_error_test() {
+  args.parse(["gleam/option.to_result", "gleam/result.to_option"])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report error for specifying multiple modules")
+}
+
+pub fn args_duplicate_flag_error_test() {
+  args.parse(["-t", "--type"])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report error for duplicate flags")
+}
+
+pub fn args_duplicate_cache_error_test() {
+  args.parse(["--cache", ".", "-C", ".."])
+  |> should.be_error
+  |> error.to_string
+  |> birdie.snap("Should report error for duplicate cache flags")
 }


### PR DESCRIPTION
I've added unit tests for the rendering code, and for argument parsing. I haven't tested any of the I/O stuff yet, because that's much trickier to test.
I used [`birdie`](https://hexdocs.pm/birdie), because that way we don't have to manually write the entire output, which can get somewhat long for certain tests.
I also tweaked a couple of things; fixed a bug where one too many type parameters was printed (turns out `list.range` is inclusive), and added either printing `type` or `value` instead of just `item` when documenting, to avoid confusion.