### PR TITLE
feat: Print current version with `--version` flag

### DIFF
--- a/birdie_snapshots/should_parse_help_argument.accepted
+++ b/birdie_snapshots/should_parse_help_argument.accepted
@@ -1,5 +1,0 @@
----
-version: 1.2.0
-title: Should parse help argument
----
-Help

--- a/src/gleamoire.gleam
+++ b/src/gleamoire.gleam
@@ -20,9 +20,12 @@ const default_cache = ".cache/gleamoire"
 
 const hexdocs_url = "https://hexdocs.pm/"
 
+const gleamoire_version = "1.0.0"
+
 fn document(args: args.Args) -> Result(String, error.Error) {
   case args {
     args.Help -> Ok(args.help_text)
+    args.Version -> Ok("Gleamoire v" <> gleamoire_version)
     args.Document(module:, print_mode:, cache_path:, refresh_cache:) ->
       resolve_input(module, print_mode, cache_path, refresh_cache)
   }

--- a/test/gleamoire_test.gleam
+++ b/test/gleamoire_test.gleam
@@ -391,8 +391,13 @@ pub fn args_test() {
 pub fn help_args_test() {
   args.parse(["--help"])
   |> should.be_ok
-  |> string.inspect
-  |> birdie.snap("Should parse help argument")
+  |> should.equal(args.Help)
+}
+
+pub fn version_args_test() {
+  args.parse(["--version"])
+  |> should.be_ok
+  |> should.equal(args.Version)
 }
 
 pub fn args_tv_error_test() {


### PR DESCRIPTION
I've added the `--version` flag. `-v` was already taken by `--value`, so I've added a special case for users trying to run `gleamoire -v`, to nudge them in the correct direction.
There's no way to get the gleam version from `gleam.toml` in the project, so we just have to duplicate it in one other place.