### PR TITLE
maint(repo): Add pre-commit hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+gleam format --check
+gleam test


### PR DESCRIPTION
A simple pre-commit hook that checks formatting and runs tests. A couple things :
  - for now we're making HTTP calls in our tests, that means that when we have to have an internet connection when we commit now, which is not ideal, we might consider mocking Hex,
  - to "install" the hook, one has to copy it to their local `.git` folder : 
```sh
cp .github/hooks/* .git/hooks
```
we might want to have a script that inits the repo once we clone it, like `make init` or `./init-repo.sh`.