### PR TITLE
feat: Qualify types outside of the current module

### DIFF
--- a/birdie_snapshots/should_print_module_constant.accepted
+++ b/birdie_snapshots/should_print_module_constant.accepted
@@ -1,9 +1,9 @@
 ---
-version: 1.2.0
+version: 1.2.1
 title: Should print module constant
 ---
 Documentation for value `constant` in `module`:
 
-pub const constant: Option(Int)
+pub const constant: option.Option(Int)
 
 This holds a constant value

--- a/birdie_snapshots/should_qualify_type_outside_current_module.accepted
+++ b/birdie_snapshots/should_qualify_type_outside_current_module.accepted
@@ -1,0 +1,11 @@
+---
+version: 1.2.1
+title: Should qualify type outside current module
+---
+Documentation for type `Wibble` in `wibble/wobble`:
+
+pub type Wibble {
+  Wibble(Int)
+  Wobble(dict.Dict(String, Int))
+  Wubble(Wibble)
+}

--- a/test/gleamoire_test.gleam
+++ b/test/gleamoire_test.gleam
@@ -407,6 +407,68 @@ pub fn item_conflict_resolution_test() {
   |> birdie.snap("Should print type with name")
 }
 
+pub fn qualify_type_test() {
+  render.document_item(
+    "Wibble",
+    "wibble/wobble",
+    pi.Module(
+      ..empty_module(),
+      types: [
+          #(
+            "Wibble",
+            pi.TypeDefinition(
+              documentation: None,
+              deprecation: None,
+              parameters: 0,
+              constructors: [
+                pi.TypeConstructor(
+                  documentation: None,
+                  name: "Wibble",
+                  parameters: [pi.Parameter(None, gleam_type("Int"))],
+                ),
+                pi.TypeConstructor(
+                  documentation: None,
+                  name: "Wobble",
+                  parameters: [
+                    pi.Parameter(
+                      None,
+                      pi.Named(
+                        name: "Dict",
+                        package: "gleam_stdlib",
+                        module: "gleam/dict",
+                        parameters: [gleam_type("String"), gleam_type("Int")],
+                      ),
+                    ),
+                  ],
+                ),
+                pi.TypeConstructor(
+                  documentation: None,
+                  name: "Wubble",
+                  parameters: [
+                    pi.Parameter(
+                      None,
+                      pi.Named(
+                        name: "Wibble",
+                        package: "package",
+                        module: "wibble/wobble",
+                        parameters: [],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ]
+        |> dict.from_list,
+    ),
+    empty_package(),
+    args.Type,
+  )
+  |> should.be_ok
+  |> birdie.snap("Should qualify type outside current module")
+}
+
 pub fn pull_known_package_test() {
   docs.get_remote_interface("argv")
   |> should.be_ok


### PR DESCRIPTION
Any types not in the gleam prelude, and not in the current module are now qualified: `dict.Dict`, `tom.Toml`, etc.